### PR TITLE
add m4a support and source order

### DIFF
--- a/site/plugins/audioext/audioext.php
+++ b/site/plugins/audioext/audioext.php
@@ -24,6 +24,7 @@ class AudioExt {
 	const CAPTION_CLASS = 'caption_class';
 	const SOURCES = 'sources';
 	
+	const TYPE_M4A = 'audio/x-aac';
 	const TYPE_MP3 = 'audio/mpeg';
 	const TYPE_OGG = 'audio/ogg';
 	const TYPE_WAV = 'audio/wav';
@@ -213,8 +214,9 @@ class AudioExt {
 			}
 				
 			// Sources
-			$audioext->addSource ( $tag->attr ( 'ogg' ), AudioExt::TYPE_OGG );
+			$audioext->addSource ( $tag->attr ( 'm4a' ), AudioExt::TYPE_M4A );
 			$audioext->addSource ( $tag->attr ( 'mp3' ), AudioExt::TYPE_MP3 );
+			$audioext->addSource ( $tag->attr ( 'ogg' ), AudioExt::TYPE_OGG );
 			$audioext->addSource ( $tag->attr ( 'wav' ), AudioExt::TYPE_WAV );
 				
 			return $audioext->toHtml ();

--- a/site/tags/audioext.php
+++ b/site/tags/audioext.php
@@ -14,6 +14,7 @@
  */
 kirbytext::$tags['audioext'] = array(
   'attr' => array(
+    'm4a',
     'mp3',
     'ogg',
     'wav',
@@ -36,6 +37,7 @@ kirbytext::$tags['audioext'] = array(
 if ( kirby()->option('kirby.extension.audioext.audio_tag') == true ) {
 	kirbytext::$tags['audio'] = array(
 			'attr' => array(
+	 	    'm4a',
 		    'mp3',
 		    'ogg',
 		    'wav',


### PR DESCRIPTION
add m4a support and changed the order of the sources: line 27 and 217-219

mp3 before ogg otherwise at least opera and chrome will cut the file to 31 sec.
